### PR TITLE
Initialise application for all types

### DIFF
--- a/src/Context/Initializer/ContextInitializer.php
+++ b/src/Context/Initializer/ContextInitializer.php
@@ -39,18 +39,15 @@ class ContextInitializer implements BehatContextInitializer
 
     public function initializeContext(Context $context): void
     {
-        if ($context instanceof Psr11AwareContext) {
-            $context->setContainer($this->factory->createContainer());
+        $container = $this->factory->createContainer();
+        $application = $this->factory->createApplication($container);
+
+        if ($context instanceof Psr11AwareContext || $context instanceof Psr11MinkAwareContext) {
+            $context->setContainer($container);
         }
 
         if ($context instanceof Psr11MinkAwareContext) {
-            $container = $this->factory->createContainer();
-
-            $application = $this->factory->createApplication($container);
             $this->kernel->setApplication($application);
-
-            /** @psalm-suppress PossiblyNullArgument */
-            $context->setContainer($container);
             $context->setMinkSession(($this->minkSessionFactory)($this->kernel));
         }
     }

--- a/src/Context/Initializer/ContextInitializer.php
+++ b/src/Context/Initializer/ContextInitializer.php
@@ -42,6 +42,14 @@ class ContextInitializer implements BehatContextInitializer
         $container = $this->factory->createContainer();
         $application = $this->factory->createApplication($container);
 
+        if ($container === null) {
+            throw new \RuntimeException(
+                'It appears you are using your own Application/Container factory and have not appropriately ' .
+                'created either the ContainerInterface or RequestHandlerInterface required for this extension to ' .
+                'function.'
+            );
+        }
+
         if ($context instanceof Psr11AwareContext || $context instanceof Psr11MinkAwareContext) {
             $context->setContainer($container);
         }

--- a/src/ServiceContainer/Factory/PsrFactory.php
+++ b/src/ServiceContainer/Factory/PsrFactory.php
@@ -7,7 +7,7 @@ namespace Acpr\Behat\Psr\ServiceContainer\Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class PsrFactory
+class PsrFactory implements PsrFactoryInterface
 {
     /**
      * @var string
@@ -25,15 +25,7 @@ class PsrFactory
     }
 
     /**
-     * Using the path to a file responsible for creating a PSR7 application
-     * will return that application.
-     *
-     * Depending on your application a PSR11 container can be made available as $container
-     *
-     * @example features/bootstrap/app.php
-     *
-     * @param ContainerInterface|null $container
-     * @return RequestHandlerInterface
+     * @inheritDoc
      */
     public function createApplication(?ContainerInterface &$container = null): RequestHandlerInterface
     {
@@ -48,12 +40,7 @@ class PsrFactory
     }
 
     /**
-     * Using the path to a file responsible for creating a PSR11 container
-     * will return that container.
-     *
-     * @example features/bootstrap/container.php
-     *
-     * @return ContainerInterface
+     * @inheritDoc
      */
     public function createContainer(): ContainerInterface
     {

--- a/src/ServiceContainer/Factory/PsrFactory.php
+++ b/src/ServiceContainer/Factory/PsrFactory.php
@@ -36,6 +36,10 @@ class PsrFactory implements PsrFactoryInterface
             throw new \InvalidArgumentException('Loaded application is not a valid PSR7 application');
         }
 
+        if ($container === null) {
+            throw new \RuntimeException('A valid PSR11 ContainerInterface has not been created as a part of the application creation');
+        }
+
         return $application;
     }
 

--- a/src/ServiceContainer/Factory/PsrFactoryInterface.php
+++ b/src/ServiceContainer/Factory/PsrFactoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acpr\Behat\Psr\ServiceContainer\Factory;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+interface PsrFactoryInterface
+{
+    /**
+     * Using the path to a file responsible for creating a PSR7 application
+     * will return that application.
+     *
+     * Depending on your application a PSR11 container can be made available as a preexisting $container
+     * or created as a part of the application initialisation.
+     *
+     * @example features/bootstrap/app.php
+     *
+     * @param ContainerInterface|null $container
+     * @return RequestHandlerInterface
+     */
+    public function createApplication(?ContainerInterface &$container = null): RequestHandlerInterface;
+
+    /**
+     * Using the path to a file responsible for creating a PSR11 container
+     * will return that container.
+     *
+     * @example features/bootstrap/container.php
+     *
+     * @return ContainerInterface
+     */
+    public function createContainer(): ContainerInterface;
+}


### PR DESCRIPTION
This initialises the application regardless of the type of context that is being used as it is possible to want to use application resources on a non-ui/web based request